### PR TITLE
Feature/changes to table

### DIFF
--- a/src/common/Input/CustomInputNumber.tsx
+++ b/src/common/Input/CustomInputNumber.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { InputWrapper, InputLabel } from './styled';
 import { InputNumber } from 'antd';
-import { get, isFunction } from 'lodash';
+import { get, isFunction, isNumber } from 'lodash';
 import { FormikHandlers } from 'formik';
 
 interface CustomInputNumberProps {
@@ -10,6 +10,7 @@ interface CustomInputNumberProps {
   setFieldValue?: (field: string, value: any) => void;
   placeholder?: string;
   autoFocus?: boolean;
+  precision?: number;
   calculateWidth?: boolean;
   smallInput?: boolean;
   ref?: React.RefObject<any>;
@@ -44,13 +45,18 @@ class CustomInputNumber extends React.PureComponent<CustomInputNumberProps> {
   }
 
   public getOptionalProps = () => {
-    const { value, calculateWidth, smallInput } = this.props;
+    const { value, calculateWidth, smallInput, precision: precisionProp } = this.props;
     const optionalProps: { [key: string]: any } = {};
     let valueLength = 1;
     if (calculateWidth) {
-      valueLength = value && value.toString().length ? value.toString().length + 1 : 1;
-      const numberSize = valueLength > 3 ? 14 : 15;
-      const width = valueLength * numberSize;
+      const intValue = Number.isNaN(Number.parseInt(value, 10)) ? 0 : Number.parseInt(value, 10);
+      valueLength = intValue.toString().length;
+      const precision = isNumber(precisionProp) && precisionProp >= 0 ? precisionProp : 2;
+      if (precision) {
+        valueLength += 1 + precision;
+      }
+      const numberSize = valueLength > 4 ? 12 : 15;
+      const width = valueLength * numberSize + 13;
       optionalProps.style = { width: `${width > 36 ? width : 36}px` };
     }
     if (smallInput) {
@@ -61,8 +67,9 @@ class CustomInputNumber extends React.PureComponent<CustomInputNumberProps> {
   }
 
   public render(): JSX.Element {
-    const { placeholder, setFieldValue, calculateWidth, ...props } = this.props;
+    const { placeholder, setFieldValue, calculateWidth, precision: precisionProp, ...props } = this.props;
     const optionalProps: { [key: string]: any } = this.getOptionalProps();
+    const precision = isNumber(precisionProp) && precisionProp >= 0 ? precisionProp : 2;
 
     return (
       <InputWrapper>
@@ -74,7 +81,7 @@ class CustomInputNumber extends React.PureComponent<CustomInputNumberProps> {
           formatter={(valueNumber) => `${valueNumber}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
           // @ts-ignore
           parser={(displayValue) => displayValue.replace(/\$\s?|(,*)/g, '')}
-          // precision={2}
+          precision={precision}
           {...optionalProps}
         />
         {placeholder && <InputLabel>{placeholder}</InputLabel>}

--- a/src/common/Input/styled.ts
+++ b/src/common/Input/styled.ts
@@ -60,6 +60,12 @@ export const InputWrapper = styled.div`
       }
     }
   }
+  .ant-select-selection {
+    height: 35px;
+    &__rendered {
+      line-height: 35px;
+    }
+  }
 `;
 
 export const InputLogin = styled(Input)``;

--- a/src/components/ClientDetailPage/DataEntry.tsx
+++ b/src/components/ClientDetailPage/DataEntry.tsx
@@ -20,6 +20,7 @@ import {
   DataEntry,
   UpdateMaritalStateAction,
   UpdateAssetsAction,
+  UpdateEmpStatus,
 } from '../../reducers/client';
 import { Button, Icon } from 'antd';
 import { ActionTableGeneral } from '../../pages/client/styled';
@@ -29,12 +30,14 @@ interface DataEntryProps {
   tagName: string;
   tabName: string;
   maritalState: string;
+  empStatus: string;
   assets?: Array<{ refId: number; description: string; type: string }>;
 
   tables?: Table;
   loading?: boolean;
   fetchDataEntry?: (payload: FetchDataEntryPayload) => FetchDataEntryAction;
   updateMaritalState?: (maritalState: string) => UpdateMaritalStateAction;
+  updateEmpStatus?: (empStatus: string) => UpdateEmpStatus;
   updateAssets?: (assets: Array<{ refId: number; description: string; type: string }>) => UpdateAssetsAction;
 }
 
@@ -95,16 +98,18 @@ class DataEntryComponent extends PureComponent<DataEntryProps> {
   }
 
   public componentDidUpdate(prevProps: Readonly<DataEntryProps>, prevState: Readonly<{}>, snapshot?: any): void {
-    const { clientId, tagName, tabName, loading, updateMaritalState, updateAssets, tables } = this.props;
+    const { clientId, tagName, tabName, loading, updateMaritalState, updateEmpStatus, tables } = this.props;
 
     if (prevProps.clientId !== clientId || prevProps.tagName !== tagName || prevProps.tabName !== tabName) {
       this.fetchDataEntry({ clientId, tagName, tabName });
     }
 
-    if (loading !== prevProps.loading && updateMaritalState && updateAssets) {
+    if (loading !== prevProps.loading && updateMaritalState && updateEmpStatus) {
       const maritalState = get(tables, 'basicInformation[0].maritalState');
+      const empStatus = get(tables, 'basicInformation[0].empStatus');
 
       updateMaritalState(maritalState);
+      updateEmpStatus(empStatus);
       this.updateAssets();
     }
   }
@@ -128,10 +133,12 @@ class DataEntryComponent extends PureComponent<DataEntryProps> {
   }
 
   public componentWillUnmount(): void {
-    const { updateMaritalState, updateAssets } = this.props;
-    // update marital state in redux store
-    if (updateMaritalState && updateAssets) {
+    const { updateMaritalState, updateEmpStatus, updateAssets } = this.props;
+
+    // update marital state, emp status, assets in redux store
+    if (updateMaritalState && updateEmpStatus && updateAssets) {
       updateMaritalState('');
+      updateEmpStatus('');
       updateAssets([]);
     }
   }
@@ -185,7 +192,7 @@ class DataEntryComponent extends PureComponent<DataEntryProps> {
   }
 
   public render() {
-    const { tables, loading, maritalState, assets } = this.props;
+    const { tables, loading, maritalState, assets, empStatus } = this.props;
     const dynamicCustomValue = pick(tables, ['inflationCPI', 'salaryInflation', 'sgcRate', 'benefitDefaultAge']);
 
     return (
@@ -236,7 +243,7 @@ class DataEntryComponent extends PureComponent<DataEntryProps> {
           render={(props: FormikProps<any>) => {
             const addRow = (row: any) => {
               const income = [...props.values.income];
-              income.unshift(row);
+              income.push(row);
 
               props.setFieldValue('income', income);
             };
@@ -274,7 +281,7 @@ class DataEntryComponent extends PureComponent<DataEntryProps> {
           render={(props: FormikProps<any>) => {
             const addRow = (row: any) => {
               const expenditure = [...props.values.expenditure];
-              expenditure.unshift(row);
+              expenditure.push(row);
 
               props.setFieldValue('expenditure', expenditure);
             };
@@ -312,7 +319,7 @@ class DataEntryComponent extends PureComponent<DataEntryProps> {
           render={(props: FormikProps<any>) => {
             const addRow = (row: any) => {
               const assetsFormValue = [...props.values.assets];
-              assetsFormValue.unshift(row);
+              assetsFormValue.push(row);
 
               props.setFieldValue('assets', assetsFormValue);
               this.updateAssets(assetsFormValue);
@@ -338,6 +345,7 @@ class DataEntryComponent extends PureComponent<DataEntryProps> {
                   maritalState={maritalState}
                   dynamicCustomValue={dynamicCustomValue}
                   updateAssets={this.updateAssets}
+                  empStatus={empStatus}
                 />
               </Form>
             );
@@ -353,7 +361,7 @@ class DataEntryComponent extends PureComponent<DataEntryProps> {
           render={(props: FormikProps<any>) => {
             const addRow = (row: any) => {
               const liabilities = [...props.values.liabilities];
-              liabilities.unshift(row);
+              liabilities.push(row);
 
               props.setFieldValue('liabilities', liabilities);
             };
@@ -391,7 +399,7 @@ class DataEntryComponent extends PureComponent<DataEntryProps> {
           render={(props: FormikProps<any>) => {
             const addRow = (row: any) => {
               const insurance = [...props.values.insurance];
-              insurance.unshift(row);
+              insurance.push(row);
 
               props.setFieldValue('insurance', insurance);
             };
@@ -439,6 +447,7 @@ const mapStateToProps = (state: RootState, ownProps: DataEntryProps) => {
   const clients = state.client.get('clients');
   const assets = state.client.get('assets');
   const maritalState = state.client.get('maritalState');
+  const empStatus = state.client.get('empStatus');
   const loading = state.client.get('loading');
   const clientId = ownProps.clientId;
   const tagName = ownProps.tagName;
@@ -460,6 +469,7 @@ const mapStateToProps = (state: RootState, ownProps: DataEntryProps) => {
     loading,
     maritalState,
     assets,
+    empStatus,
   };
 };
 
@@ -468,6 +478,7 @@ const mapDispatchToProps = (dispatch: Dispatch<StandardAction<any>>) =>
     {
       fetchDataEntry: ClientActions.fetchDataEntry,
       updateMaritalState: ClientActions.updateMaritalState,
+      updateEmpStatus: ClientActions.updateEmpStatus,
       updateAssets: ClientActions.updateAssets,
     },
     dispatch,

--- a/src/components/ClientDetailPage/assets/AssetsTable.tsx
+++ b/src/components/ClientDetailPage/assets/AssetsTable.tsx
@@ -12,6 +12,7 @@ interface AssetsTableProps {
   data: object[];
   maritalState: string;
   dynamicCustomValue: object;
+  empStatus: string;
   loading?: boolean;
 
   formProps?: FormikProps<any>;
@@ -165,8 +166,8 @@ class AssetsTable extends PureComponent<AssetsTableProps> {
 
   public addRowInnerTable = (index: number, tableName: string, row: any) => {
     const { setFieldValue, data } = this.props;
-    const tableData = get(data[index], tableName);
-    tableData.unshift(row);
+    const tableData = get(data[index], tableName, []);
+    tableData.push(row);
 
     const newData: any = data;
     newData[index][tableName] = tableData;
@@ -185,7 +186,7 @@ class AssetsTable extends PureComponent<AssetsTableProps> {
   }
 
   public render() {
-    const { loading, data, maritalState, dynamicCustomValue } = this.props;
+    const { loading, data, maritalState, dynamicCustomValue, empStatus } = this.props;
     const columns = this.columns.map((col: any) => {
       const editable = col.editable === false ? false : 'true';
       if (col.key === 'operation') {
@@ -242,6 +243,7 @@ class AssetsTable extends PureComponent<AssetsTableProps> {
               addRow={this.addRowInnerTable}
               deleteRow={this.removeRowInnerTable}
               dynamicCustomValue={dynamicCustomValue}
+              empStatus={empStatus}
             />
           )}
           className={`${this.tableName}-table`}

--- a/src/components/ClientDetailPage/assets/EditableCell.tsx
+++ b/src/components/ClientDetailPage/assets/EditableCell.tsx
@@ -13,6 +13,7 @@ interface EditableProps {
   handleSave?: (arg: object) => void;
   title?: string;
   editable?: boolean;
+  precision?: number;
   disableRowIndex?: boolean;
   tableName?: string;
   rowIndex?: number;
@@ -79,6 +80,7 @@ export default class EditableCell extends React.PureComponent<EditableProps> {
       expandedField,
       calculateWidth,
       defaultValue,
+      precision,
     } = props;
     const appendProps = [];
 
@@ -89,6 +91,11 @@ export default class EditableCell extends React.PureComponent<EditableProps> {
       }
       case 'date': {
         appendProps.push({ defaultOpen: editing, pickerType, options, disabledYear });
+        break;
+      }
+      case 'number': {
+        appendProps.push({ precision });
+        break;
       }
     }
 

--- a/src/components/ClientDetailPage/assets/ExpandedAssetsRowWrapper.tsx
+++ b/src/components/ClientDetailPage/assets/ExpandedAssetsRowWrapper.tsx
@@ -20,6 +20,7 @@ import {
   contributionWithdrawalsTypeOptions,
   EMP_STATUS,
   from1Options,
+  INVESTMENT_TYPES,
   isOrNotOptions,
   MARITAL_STATE,
   to1Options,
@@ -30,6 +31,7 @@ import PensionIncomeTable from './PensionIncomeTable';
 export interface AssetProps {
   description: string;
   type: string;
+  investment: string;
   expandable: {
     riskProfile?: string;
     adviserFeeType?: string;
@@ -128,6 +130,10 @@ const ExpandedAssetsRow = (props: {
 
   switch (type) {
     case 'lifestyle':
+      if (INVESTMENT_TYPES[record.investment] !== INVESTMENT_TYPES.primaryResidence) {
+        return null;
+      }
+
       return (
         <ExpandedAssetsBlock>
           <ExpandedAssetsInlineGroups>
@@ -146,6 +152,35 @@ const ExpandedAssetsRow = (props: {
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
             <ExpandedAssetsText>each year</ExpandedAssetsText>
+          </ExpandedAssetsInlineGroups>
+          <ExpandedAssetsInlineGroups>
+            <ExpandedAssetsText>The (Lifestyle Asset) has a cost base of</ExpandedAssetsText>
+            <PrefixSingleGroup dollar={true}>
+              <TypeDollarPrefix>$</TypeDollarPrefix>
+              <EditableCell
+                record={record}
+                dataIndex={'expandable.costBase'}
+                type={'number'}
+                tableName={'assets'}
+                rowIndex={index}
+                editable={true}
+                expandedField={true}
+              />
+            </PrefixSingleGroup>
+            <ExpandedAssetsText>and</ExpandedAssetsText>
+            <ExpandedSelectGroup>
+              <EditableCell
+                record={record}
+                dataIndex={'expandable.isCGTAssessable'}
+                type={'select'}
+                tableName={'assets'}
+                options={isOrNotOptions}
+                rowIndex={index}
+                editable={true}
+                expandedField={true}
+              />
+            </ExpandedSelectGroup>
+            <ExpandedAssetsText>CGT assessable</ExpandedAssetsText>
           </ExpandedAssetsInlineGroups>
         </ExpandedAssetsBlock>
       );

--- a/src/components/ClientDetailPage/assets/ExpandedAssetsRowWrapper.tsx
+++ b/src/components/ClientDetailPage/assets/ExpandedAssetsRowWrapper.tsx
@@ -18,6 +18,7 @@ import {
 import {
   CONTRIBUTION_WITHDRAWALS_TYPE,
   contributionWithdrawalsTypeOptions,
+  EMP_STATUS,
   from1Options,
   isOrNotOptions,
   MARITAL_STATE,
@@ -110,8 +111,9 @@ const ExpandedAssetsRow = (props: {
   addRow: (index: number, tableName: string, row: any) => void;
   deleteRow: (index: number, tableName: string, key: number) => void;
   dynamicCustomValue: object;
+  empStatus: string;
 }) => {
-  const { record, maritalState, index, addRow, deleteRow, dynamicCustomValue } = props;
+  const { record, maritalState, index, addRow, deleteRow, dynamicCustomValue, empStatus } = props;
   const { expandable, type } = record;
   const contributionWithdrawalColumns = [...defaultContributionWithdrawalColumns];
   if (MARITAL_STATE[maritalState] === MARITAL_STATE.single) {
@@ -497,13 +499,15 @@ const ExpandedAssetsRow = (props: {
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
           </ExpandedAssetsInlineGroups>
-          <SGContributionTable
-            data={(record.sgContribution && [{ key: 0, ...record.sgContribution }]) || []}
-            index={index}
-            tableName={'sgContribution'}
-            titleTable={'SG Contribution'}
-            dynamicCustomValue={dynamicCustomValue}
-          />
+          {EMP_STATUS[empStatus] === EMP_STATUS.employed && (
+            <SGContributionTable
+              data={(record.sgContribution && [{ key: 0, ...record.sgContribution }]) || []}
+              index={index}
+              tableName={'sgContribution'}
+              titleTable={'SG Contribution'}
+              dynamicCustomValue={dynamicCustomValue}
+            />
+          )}
           <ContributionWithdrawalsTable
             data={record.contributionWithdrawals || []}
             index={index}

--- a/src/components/ClientDetailPage/assets/ExpandedAssetsRowWrapper.tsx
+++ b/src/components/ClientDetailPage/assets/ExpandedAssetsRowWrapper.tsx
@@ -139,6 +139,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -160,6 +161,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -173,6 +175,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -186,6 +189,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -249,6 +253,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -337,6 +342,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -350,6 +356,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -363,6 +370,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -437,6 +445,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -483,6 +492,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -521,6 +531,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -534,6 +545,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -547,6 +559,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -638,6 +651,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -698,6 +712,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={1}
               />
               <TypePercentPrefix>%</TypePercentPrefix>
             </PrefixSingleGroup>
@@ -743,6 +758,7 @@ const ExpandedAssetsRow = (props: {
                 rowIndex={index}
                 editable={true}
                 expandedField={true}
+                precision={0}
               />
             </PrefixSingleGroup>
             <ExpandedAssetsText>per month</ExpandedAssetsText>

--- a/src/components/ClientDetailPage/basicInformation/BasicInformationTable.tsx
+++ b/src/components/ClientDetailPage/basicInformation/BasicInformationTable.tsx
@@ -172,15 +172,19 @@ class BasicInformationTable extends PureComponent<BasicInformationProps> {
     const columns = this.columns.map((col) => {
       return {
         ...col,
-        onCell: (record: any, rowIndex: number) => ({
-          ...col,
-          rowIndex,
-          tableName: this.tableName,
-          type: col.type || 'text',
-          record,
-          editable: 'true',
-          handleSave: this.handleSave,
-        }),
+        onCell: (record: any, rowIndex: number) => {
+          const editable = rowIndex === 1 && col.dataIndex === 'maritalState' ? false : 'true';
+
+          return {
+            ...col,
+            rowIndex,
+            tableName: this.tableName,
+            type: col.type || 'text',
+            record,
+            editable,
+            handleSave: this.handleSave,
+          };
+        },
       };
     });
 

--- a/src/components/ClientDetailPage/basicInformation/BasicInformationTable.tsx
+++ b/src/components/ClientDetailPage/basicInformation/BasicInformationTable.tsx
@@ -8,7 +8,7 @@ import { isFunction } from 'lodash';
 import { connect } from 'react-redux';
 import { StandardAction } from '../../../reducers/reducerTypes';
 import { bindActionCreators, Dispatch } from 'redux';
-import { ClientActions, UpdateMaritalStateAction } from '../../../reducers/client';
+import { ClientActions, UpdateEmpStatus, UpdateMaritalStateAction } from '../../../reducers/client';
 import { empStatusOptions, genderOptions, maritalStateOptions } from '../../../enums/options';
 
 interface BasicInformationProps {
@@ -24,6 +24,7 @@ interface BasicInformationProps {
   deleteRow: (key: number) => void;
 
   updateMaritalState?: (maritalState: string) => UpdateMaritalStateAction;
+  updateEmpStatus?: (empStatus: string) => UpdateEmpStatus;
 }
 
 class BasicInformationTable extends PureComponent<BasicInformationProps> {
@@ -135,18 +136,26 @@ class BasicInformationTable extends PureComponent<BasicInformationProps> {
     /**
      * side effect
      */
-    if (rowIndex === 0 && dataIndex === 'maritalState') {
-      const { updateMaritalState } = this.props;
-      // update marital state in redux store
-      if (updateMaritalState) {
-        updateMaritalState(value);
-      }
+    if (rowIndex === 0) {
+      if (dataIndex === 'maritalState') {
+        const { updateMaritalState } = this.props;
+        // update marital state in redux store
+        if (updateMaritalState) {
+          updateMaritalState(value);
+        }
 
-      if (value === 'single') {
-        this.handleDelete(1);
+        if (value === 'single') {
+          this.handleDelete(1);
+        }
+        if (value === 'married') {
+          this.handleAdd();
+        }
       }
-      if (value === 'married') {
-        this.handleAdd();
+      if (dataIndex === 'empStatus') {
+        const { updateEmpStatus } = this.props;
+        if (updateEmpStatus) {
+          updateEmpStatus(value);
+        }
       }
     }
   }
@@ -208,6 +217,7 @@ const mapDispatchToProps = (dispatch: Dispatch<StandardAction<any>>) =>
   bindActionCreators(
     {
       updateMaritalState: ClientActions.updateMaritalState,
+      updateEmpStatus: ClientActions.updateEmpStatus,
     },
     dispatch,
   );

--- a/src/components/ClientDetailPage/insurance/CoverDetailsTable.tsx
+++ b/src/components/ClientDetailPage/insurance/CoverDetailsTable.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { map } from 'lodash';
 import { Icon, Popconfirm, Table } from 'antd';
 import { InnerTableContainer, DivideLine, HeaderTitleTable, TextTitle } from '../../../pages/client/styled';
 import { components } from '../assets/ContributionWithdrawalsTable';
@@ -138,7 +139,7 @@ class CoverDetailsTable extends Component<CoverDetailsProps> {
           className={'cover-details-table'}
           dataSource={data}
           components={components}
-          defaultExpandAllRows={true}
+          expandedRowKeys={map(data, 'key')}
           expandedRowRender={(record: CoverDetail, expandedIndex: number, indent: number, expanded: boolean) => (
             <ExpandedCoverDetailRow
               record={record}

--- a/src/components/ClientDetailPage/insurance/CoverDetailsTable.tsx
+++ b/src/components/ClientDetailPage/insurance/CoverDetailsTable.tsx
@@ -4,6 +4,7 @@ import { InnerTableContainer, DivideLine, HeaderTitleTable, TextTitle } from '..
 import { components } from '../assets/ContributionWithdrawalsTable';
 import { coverTypeOptions, policyOwnerOptions, premiumTypeOptions } from '../../../enums/options';
 import ExpandedCoverDetailRow from './ExpandedCoverDetailRow';
+import { loadOptionsBaseOnCol } from '../../../utils/columnUtils';
 
 export interface CoverDetail {
   key: number;
@@ -23,6 +24,7 @@ interface CoverDetailsProps {
   addRow: (index: number, tableName: string, row: any) => void;
   deleteRow: (index: number, tableName: string, key: number) => void;
   dynamicCustomValue: object;
+  maritalState: string;
 }
 
 class CoverDetailsTable extends Component<CoverDetailsProps> {
@@ -100,22 +102,27 @@ class CoverDetailsTable extends Component<CoverDetailsProps> {
   }
 
   public render() {
-    const { data, index, tableName, dynamicCustomValue } = this.props;
-    const columns = this.columns.map((col) => {
+    const { data, index, tableName, dynamicCustomValue, maritalState } = this.props;
+    const columns = this.columns.map((col: any) => {
       const editable = col.key === 'operation' ? false : 'true';
 
       return {
         ...col,
         fixed: false,
-        onCell: (record: any, rowIndex: number) => ({
-          ...col,
-          rowIndex,
-          tableName: `insurance[${index}].${tableName}`,
-          type: col.type || 'text',
-          record,
-          editable,
-          smallInput: true,
-        }),
+        onCell: (record: any, rowIndex: number) => {
+          const options = loadOptionsBaseOnCol(col, record, { maritalState });
+
+          return {
+            ...col,
+            options,
+            rowIndex,
+            tableName: `insurance[${index}].${tableName}`,
+            type: col.type || 'text',
+            record,
+            editable,
+            smallInput: true,
+          };
+        },
       };
     });
 

--- a/src/components/ClientDetailPage/insurance/ExpandedCoverDetailRow.tsx
+++ b/src/components/ClientDetailPage/insurance/ExpandedCoverDetailRow.tsx
@@ -226,6 +226,7 @@ const ExpandedCoverDetailRow = (props: {
                 type={'number'}
                 editable={true}
                 expandedField={true}
+                precision={0}
               />
             </PrefixSingleGroup>
             <ExpandedSelectGroup>
@@ -264,6 +265,7 @@ const ExpandedCoverDetailRow = (props: {
                   type={'number'}
                   editable={true}
                   expandedField={true}
+                  precision={0}
                 />
               </PrefixSingleGroup>
             )}

--- a/src/components/ClientDetailPage/insurance/ExpandedInsuranceRow.tsx
+++ b/src/components/ClientDetailPage/insurance/ExpandedInsuranceRow.tsx
@@ -15,8 +15,9 @@ const ExpandedInsuranceRow = (props: {
   addRow: (index: number, tableName: string, row: any) => void;
   deleteRow: (index: number, tableName: string, key: number) => void;
   dynamicCustomValue: object;
+  maritalState: string;
 }) => {
-  const { record, index, addRow, deleteRow, dynamicCustomValue } = props;
+  const { record, index, addRow, deleteRow, dynamicCustomValue, maritalState } = props;
   const { coverDetails, premiumFeeDetails } = record;
 
   return (
@@ -28,6 +29,7 @@ const ExpandedInsuranceRow = (props: {
         addRow={addRow}
         deleteRow={deleteRow}
         dynamicCustomValue={dynamicCustomValue}
+        maritalState={maritalState}
       />
       <PremiumFeeDetailsTable
         data={premiumFeeDetails}

--- a/src/components/ClientDetailPage/insurance/InsuranceTable.tsx
+++ b/src/components/ClientDetailPage/insurance/InsuranceTable.tsx
@@ -200,6 +200,7 @@ class InsuranceTable extends PureComponent<InsuranceTableProps> {
               addRow={this.addRowInnerTable}
               deleteRow={this.removeRowInnerTable}
               dynamicCustomValue={dynamicCustomValue}
+              maritalState={maritalState}
             />
           )}
           className={`${this.tableName}-table`}

--- a/src/components/ClientDetailPage/insurance/InsuranceTable.tsx
+++ b/src/components/ClientDetailPage/insurance/InsuranceTable.tsx
@@ -127,8 +127,8 @@ class InsuranceTable extends PureComponent<InsuranceTableProps> {
 
   public addRowInnerTable = (index: number, tableName: string, row: any) => {
     const { setFieldValue, data } = this.props;
-    const tableData = get(data[index], tableName);
-    tableData.unshift(row);
+    const tableData = get(data[index], tableName, []);
+    tableData.push(row);
 
     const newData: any = data;
     newData[index][tableName] = tableData;

--- a/src/components/ClientDetailPage/liabilities/ExpandedLiabilitiesRow.tsx
+++ b/src/components/ClientDetailPage/liabilities/ExpandedLiabilitiesRow.tsx
@@ -45,11 +45,12 @@ const ExpandedLiabilitiesRow = (props: {
           <EditableCell
             record={record}
             dataIndex={'expandable.deductibility'}
-            type={'text'}
+            type={'number'}
             tableName={'liabilities'}
             rowIndex={index}
             editable={true}
             expandedField={true}
+            precision={1}
           />
           <TypePercentPrefix>%</TypePercentPrefix>
         </PrefixSingleGroup>
@@ -61,7 +62,7 @@ const ExpandedLiabilitiesRow = (props: {
           <EditableCell
             record={record}
             dataIndex={'expandable.repaymentAmount'}
-            type={'text'}
+            type={'number'}
             tableName={'liabilities'}
             rowIndex={index}
             editable={true}
@@ -86,11 +87,12 @@ const ExpandedLiabilitiesRow = (props: {
           <EditableCell
             record={record}
             dataIndex={'expandable.durationLength'}
-            type={'text'}
+            type={'number'}
             tableName={'liabilities'}
             rowIndex={index}
             editable={true}
             expandedField={true}
+            precision={0}
           />
         </PrefixSingleGroup>
         <ExpandedSelectGroup>
@@ -113,7 +115,7 @@ const ExpandedLiabilitiesRow = (props: {
           <EditableCell
             record={record}
             dataIndex={'expandable.creditLimit'}
-            type={'text'}
+            type={'number'}
             tableName={'liabilities'}
             rowIndex={index}
             editable={true}

--- a/src/components/ClientDetailPage/liabilities/LiabilitiesTable.tsx
+++ b/src/components/ClientDetailPage/liabilities/LiabilitiesTable.tsx
@@ -166,8 +166,8 @@ class LiabilitiesTable extends PureComponent<LiabilitiesTableProps> {
 
   public addRowInnerTable = (index: number, tableName: string, row: any) => {
     const { setFieldValue, data } = this.props;
-    const tableData = get(data[index], tableName);
-    tableData.unshift(row);
+    const tableData = get(data[index], tableName, []);
+    tableData.push(row);
 
     const newData: any = data;
     newData[index][tableName] = tableData;

--- a/src/components/ClientDetailPage/liabilities/LiabilitiesTable.tsx
+++ b/src/components/ClientDetailPage/liabilities/LiabilitiesTable.tsx
@@ -59,6 +59,7 @@ class LiabilitiesTable extends PureComponent<LiabilitiesTableProps> {
       key: '4',
       width: '13%',
       type: 'number',
+      precision: 1,
     },
     {
       title: 'From',

--- a/src/components/Elements/FormInput/FormInput.tsx
+++ b/src/components/Elements/FormInput/FormInput.tsx
@@ -27,6 +27,7 @@ interface InputProps {
   // CustomInputNumber Number
   min?: number;
   max?: number;
+  precision?: number;
   calculateWidth?: boolean;
   // Select
   options?: Array<{ value: any; label: string }>;

--- a/src/enums/options.ts
+++ b/src/enums/options.ts
@@ -35,7 +35,7 @@ export const OWNER_WITH_JOINT = {
 };
 export const ownerWithJointOptions = mapOptionObjectToArray(OWNER_WITH_JOINT);
 
-export const EMP_STATUS = {
+export const EMP_STATUS: { [key: string]: string } = {
   employed: 'Employed',
   selfEmployed: 'Self Employed',
   retired: 'Retired',

--- a/src/enums/options.ts
+++ b/src/enums/options.ts
@@ -123,7 +123,7 @@ export const ASSET_TYPES: { [key: string]: string } = {
 };
 export const assetTypes = mapOptionObjectToArray(ASSET_TYPES);
 
-export const INVESTMENT_TYPES = {
+export const INVESTMENT_TYPES: { [key: string]: string } = {
   primaryResidence: 'Primary Residence',
   australianEquity: 'Australian Equity',
   preservation: 'Preservation',

--- a/src/pages/client/Client.tsx
+++ b/src/pages/client/Client.tsx
@@ -16,7 +16,7 @@ class Client extends React.PureComponent<RouteComponentProps> {
     const tabName = get(match, 'params.tabName');
 
     return tagName ? (
-      <DataEntryComponent clientId={clientId} tabName={tabName} tagName={tagName} />
+      <DataEntryComponent clientId={clientId} tabName={tabName} tagName={tagName} empStatus={''} />
     ) : (
       <HomePage select>
         <Content>

--- a/src/reducers/client/clientActions.ts
+++ b/src/reducers/client/clientActions.ts
@@ -4,6 +4,7 @@ import {
   FetchDataEntryPayload,
   UpdateMaritalStateAction,
   UpdateAssetsAction,
+  UpdateEmpStatus,
 } from './clientTypes';
 import { createPayloadAction } from '../reducerHelpers';
 
@@ -12,6 +13,8 @@ export default class ClientActions {
     createPayloadAction(ClientActionTypes.FETCH_DATA_ENTRY_REQUEST, payload)
   public static updateMaritalState = (maritalState: string): UpdateMaritalStateAction =>
     createPayloadAction(ClientActionTypes.UPDATE_MARITAL_STATE, maritalState)
+  public static updateEmpStatus = (empStatus: string): UpdateEmpStatus =>
+    createPayloadAction(ClientActionTypes.UPDATE_EMP_STATUS, empStatus)
   public static updateAssets = (
     assets: Array<{ refId: number; description: string; type: string }>,
   ): UpdateAssetsAction => createPayloadAction(ClientActionTypes.UPDATE_ASSETS, assets)

--- a/src/reducers/client/clientReducer.ts
+++ b/src/reducers/client/clientReducer.ts
@@ -25,6 +25,8 @@ export default class ClientReducer {
         return ClientReducer.fetchDataEntry(state, action);
       case ClientActionTypes.UPDATE_MARITAL_STATE:
         return ClientReducer.updateMaritalState(state, action);
+      case ClientActionTypes.UPDATE_EMP_STATUS:
+        return ClientReducer.updateEmpStatus(state, action);
       case ClientActionTypes.UPDATE_ASSETS:
         return ClientReducer.updateAssets(state, action);
       default:
@@ -94,6 +96,10 @@ export default class ClientReducer {
 
   private static updateMaritalState(state: ClientState, action: StandardAction<any>): ClientState {
     return state.set('maritalState', action.payload);
+  }
+
+  private static updateEmpStatus(state: ClientState, action: StandardAction<any>): ClientState {
+    return state.set('empStatus', action.payload);
   }
 
   private static updateAssets(state: ClientState, action: StandardAction<any>): ClientState {

--- a/src/reducers/client/clientTypes.ts
+++ b/src/reducers/client/clientTypes.ts
@@ -33,6 +33,7 @@ export interface ClientState {
   loading?: boolean;
   error?: string;
   maritalState: string;
+  empStatus: string;
   assets: Array<{ refId: number; description: string; type: string }>;
 
   [propsName: string]: any;
@@ -62,6 +63,7 @@ export const defaultClientState: ClientState = {
   ],
   assets: [],
   maritalState: '',
+  empStatus: '',
   loading: false,
   error: '',
 };
@@ -75,13 +77,14 @@ export class ClientStateRecord extends Record(defaultClientState) implements Cli
 
 // Define action types
 export enum ClientActionTypes {
-  FETCH_CLIENT_REQUEST = 'client/FETCH_CLIENT_REQUEST',
-  FETCH_CLIENT_SUCCESS = 'client/FETCH_CLIENT_SUCCESS',
-  FETCH_CLIENT_FAILURE = 'client/FETCH_CLIENT_FAILURE',
+  FETCH_CLIENTS_REQUEST = 'client/FETCH_CLIENTS_REQUEST',
+  FETCH_CLIENTS_SUCCESS = 'client/FETCH_CLIENTS_SUCCESS',
+  FETCH_CLIENTS_FAILURE = 'client/FETCH_CLIENTS_FAILURE',
   FETCH_DATA_ENTRY_REQUEST = 'client/FETCH_DATA_ENTRY_REQUEST',
   FETCH_DATA_ENTRY_SUCCESS = 'client/FETCH_DATA_ENTRY_SUCCESS',
   FETCH_DATA_ENTRY_FAILURE = 'client/FETCH_DATA_ENTRY_FAILURE',
   UPDATE_MARITAL_STATE = 'client/UPDATE_MARITAL_STATE',
+  UPDATE_EMP_STATUS = 'client/UPDATE_EMP_STATUS',
   UPDATE_ASSETS = 'client/UPDATE_ASSETS',
 }
 
@@ -93,6 +96,7 @@ export interface FetchDataEntryPayload {
 
 export type FetchDataEntryAction = PayloadAction<ClientActionTypes.FETCH_DATA_ENTRY_REQUEST, FetchDataEntryPayload>;
 export type UpdateMaritalStateAction = PayloadAction<ClientActionTypes.UPDATE_MARITAL_STATE, string>;
+export type UpdateEmpStatus = PayloadAction<ClientActionTypes.UPDATE_EMP_STATUS, string>;
 export type UpdateAssetsAction = PayloadAction<
   ClientActionTypes.UPDATE_ASSETS,
   Array<{ description: string; type: string; refId: number }>

--- a/src/utils/columnUtils.ts
+++ b/src/utils/columnUtils.ts
@@ -1,4 +1,12 @@
-import { ASSET_TYPES, FROM_1, investmentTypeOptions, maritalStateOptions, OWNER } from '../enums/options';
+import {
+  ASSET_TYPES,
+  COVER_TYPE,
+  FROM_1,
+  investmentTypeOptions,
+  maritalStateOptions,
+  OWNER,
+  POLICY_OWNER,
+} from '../enums/options';
 
 export function addJointOption(
   col: { dataIndex: string },
@@ -34,6 +42,7 @@ export function removePartnerOption(
         result = result.filter((option: any) => option.label !== FROM_1.partnerRetirement);
         break;
       }
+      case 'policyOwner':
       case 'owner': {
         result = result.filter((option: any) => option.label !== OWNER.partner);
       }
@@ -98,9 +107,13 @@ function loadInvestmentOptions(record: { type: string }) {
   return investmentTypeOptions;
 }
 
+export function removeSuperFund(options: Array<{ value: any; label: any }>) {
+  return options.filter((option: any) => option.label !== POLICY_OWNER.superFund);
+}
+
 export function loadOptionsBaseOnCol(
   col: { dataIndex: string; options?: Array<{ value: any; label: any }> },
-  record: { type: string },
+  record: { type: string; coverType?: string },
   customValue: { maritalState?: string; dynamicCustomValue?: object },
 ) {
   const { maritalState, dynamicCustomValue } = customValue;
@@ -124,6 +137,14 @@ export function loadOptionsBaseOnCol(
     }
     if (col.dataIndex === 'investment' && record.type && options) {
       options = loadInvestmentOptions(record);
+    }
+    if (col.dataIndex === 'policyOwner' && options && record.coverType) {
+      if (
+        COVER_TYPE[record.coverType] === COVER_TYPE.trauma ||
+        COVER_TYPE[record.coverType] === COVER_TYPE.childTrauma
+      ) {
+        options = removeSuperFund(options);
+      }
     }
 
     return options;


### PR DESCRIPTION
Ref: kodiakorg/financial#36

TODO
-----

- [x] No SuperFund option for Trauma and Child Trauma.
- [x] Super asset row, SG Contribution table. If employment status (empStatus) is NOT ‘Employed,’ then disable this section.
- [x] Disable Marital State of Partner row.
- [x] In Insurance table, add new Cover, then expand row by default.
