### PR TITLE
Feature/request 08 12 2019

### DIFF
--- a/src/components/StrategyPage/StrategyTable/CustomizedExistingInvestment.tsx
+++ b/src/components/StrategyPage/StrategyTable/CustomizedExistingInvestment.tsx
@@ -4,7 +4,7 @@ import { FullyCustomized } from '../Drawer/styled';
 import EditCell, { EditCellType } from '../Drawer/EditCell';
 import { find, get, random, map } from 'lodash';
 import { getOptions, StrategyItemProps } from './StrategyItem';
-import { specificOptions } from '../../../enums/strategySentences';
+import { periodTypes, specificOptions } from '../../../enums/strategySentences';
 
 const CustomizedExistingInvestment = (
   props: StrategyItemProps & { name: string; context: string; sentenceKey: string; defaultFullValue: number },
@@ -24,7 +24,7 @@ const CustomizedExistingInvestment = (
   const investmentOptions = getOptions(context, { client, partner }, 'investments');
   const investmentOptions2 = [...investmentOptions, { value: 'cashflow', label: 'Cashflow' }];
   const [fullValue, setFullValue] = React.useState<number>(
-    get(find(investmentOptions, { value: get(strategy, 'values[3]') }), 'fullValue', 0),
+    get(find(investmentOptions, { value: get(strategy, ['values', isRegular ? 5 : 3]) }), 'fullValue', 0),
   );
   const updateFullValue = (val: any, fieldName: string) => {
     setFieldValue(fieldName, val);
@@ -34,25 +34,42 @@ const CustomizedExistingInvestment = (
   if (isRegular) {
     return (
       <FullyCustomized>
-        {fullName}, make a regular contribution into{' '}
+        {fullName}, make a regular contribution of
         <EditCell
           name={`${strategyType}.strategies[${strategyIndex}].values[0]`}
           value={get(strategy, 'values[0]')}
+          type={EditCellType.number}
+          onChange={(val, fieldName) => setFieldValue(fieldName, val)}
+          dollar={true}
+          calculateWidth={true}
+        />
+        per
+        <EditCell
+          name={`${strategyType}.strategies[${strategyIndex}].values[1]`}
+          value={get(strategy, 'values[1]')}
+          onChange={(val, fieldName) => setFieldValue(fieldName, val)}
+          type={EditCellType.select}
+          options={periodTypes}
+        />
+        into
+        <EditCell
+          name={`${strategyType}.strategies[${strategyIndex}].values[2]`}
+          value={get(strategy, 'values[2]')}
           type={EditCellType.select}
           options={investmentOptions}
           onChange={(val, name) => setFieldValue(name, val)}
         />
         from
         <EditCell
-          name={`${strategyType}.strategies[${strategyIndex}].values[1]`}
-          value={get(strategy, 'values[1]')}
+          name={`${strategyType}.strategies[${strategyIndex}].values[3]`}
+          value={get(strategy, 'values[3]')}
           type={EditCellType.date}
           onChange={(val, name) => setFieldValue(name, val)}
         />
         to
         <EditCell
-          name={`${strategyType}.strategies[${strategyIndex}].values[2]`}
-          value={get(strategy, 'values[2]')}
+          name={`${strategyType}.strategies[${strategyIndex}].values[4]`}
+          value={get(strategy, 'values[4]')}
           type={EditCellType.date}
           onChange={(val, name) => setFieldValue(name, val)}
         />
@@ -60,8 +77,8 @@ const CustomizedExistingInvestment = (
         <span>
           The contributions are to be funded from
           <EditCell
-            name={`${strategyType}.strategies[${strategyIndex}].values[3]`}
-            value={get(strategy, 'values[3]')}
+            name={`${strategyType}.strategies[${strategyIndex}].values[5]`}
+            value={get(strategy, 'values[5]')}
             type={EditCellType.select}
             options={investmentOptions2}
             onChange={(val, name) => setFieldValue(name, val)}

--- a/src/components/StrategyPage/StrategyTable/CustomizedPension.tsx
+++ b/src/components/StrategyPage/StrategyTable/CustomizedPension.tsx
@@ -22,7 +22,7 @@ const CustomizedPension = (
     setFieldValue,
   } = props;
   const id = strategy.id || `${strategyIndex}-superannuation`;
-  const pensionIncomeOptions = map(getOptions(context, { client, partner }, 'pensionIncome'), option => ({
+  const pensionIncomeOptions = map(getOptions(context, { client, partner }, 'pensionIncome'), (option) => ({
     ...option,
     label: option.income ? `${option.label} $(${numeral(option.income).format('0,0')})` : option.label,
   }));
@@ -126,7 +126,7 @@ const CustomizedPension = (
                 name={`${strategyType}.strategies[${strategyIndex}].values[4][${index}]`}
                 type={EditCellType.number}
                 value={get(strategy, ['values', 4, index])}
-                onChange={val => {
+                onChange={(val) => {
                   asyncUpdateFullValue(val);
                 }}
                 dollar={true}
@@ -146,7 +146,7 @@ const CustomizedPension = (
           value={pensionIncome}
           type={EditCellType.select}
           options={pensionIncomeOptions}
-          onChange={val => setPensionIncome(val)}
+          onChange={(val) => setPensionIncome(val)}
         />{' '}
         {pensionIncome === 'specific' && (
           <EditCell

--- a/src/enums/strategySentences.ts
+++ b/src/enums/strategySentences.ts
@@ -1,4 +1,4 @@
-import {EditCellType} from '../components/StrategyPage/Drawer/EditCell';
+import { EditCellType } from '../components/StrategyPage/Drawer/EditCell';
 
 export const specificOptions = [{ value: 'specific', label: 'Specific' }, { value: 'custom', label: 'Custom' }];
 export const ddFreeTextOptions = [
@@ -36,28 +36,29 @@ export const paydownOptions = [
 const strategySentences: any = {
   salarySacrifice: {
     maximise: {
-      statement: '%name%, maximise salary sacrifice contributions from {{0}} to {{1}}',
-      types: [EditCellType.date, EditCellType.date],
+      statement: '%name%, maximise salary sacrifice contributions into {{0}} from {{1}} to {{2}}',
+      types: [EditCellType.select, EditCellType.date, EditCellType.date],
+      options: ['superannuation'],
     },
     fixedRegular: {
       /**
        * %name%, name is a key of client/partner object in JSON, we will render the value of this key to layout
        * {{0}} indicate to input
        */
-      statement: '%name%, salary sacrifice {{0}} per {{1}} from {{2}} to {{3}}',
-      types: [EditCellType.number, EditCellType.select, EditCellType.date, EditCellType.date],
+      statement: '%name%, salary sacrifice {{0}} per {{1}} into {{2}} from {{3}} to {{4}}',
+      types: [EditCellType.number, EditCellType.select, EditCellType.select, EditCellType.date, EditCellType.date],
       /**
        * - option is a string, we understand the option is a key of client/partner object in JSON,
        *  for example: superannuation, investments, loans,...
        * - options is `year`, we should use a custom options
        * - options is an array, we set the values of option as a options of select
        */
-      options: ['', periodTypes],
+      options: ['', periodTypes, 'superannuation'],
     },
     customOneOff: {
-      statement: '%name%, salary sacrifice {{0}} in {{1}}',
-      types: [EditCellType.number, EditCellType.select],
-      options: ['', 'year'],
+      statement: '%name%, salary sacrifice {{0}} into {{1}} in {{2}}',
+      types: [EditCellType.number, EditCellType.select, EditCellType.select],
+      options: ['', 'superannuation', 'year'],
     },
   },
   nonConcessional: {
@@ -122,7 +123,8 @@ const strategySentences: any = {
   },
   recontribution: {
     statement:
-      '%name%, withdraw {{0}} from superannuation and recontribute {{1}}' + 'back into superannuation in {{2}}. ' +
+      '%name%, withdraw {{0}} from superannuation and recontribute {{1}}' +
+      'back into superannuation in {{2}}. ' +
       'This contribution is to be funded from {{3}}',
     types: [EditCellType.dropdownFreeText, EditCellType.dropdownFreeText, EditCellType.select, EditCellType.select],
     options: ['', '', 'year', 'superannuation'],

--- a/src/enums/strategySentences.ts
+++ b/src/enums/strategySentences.ts
@@ -135,46 +135,17 @@ const strategySentences: any = {
   existingInvestment: {
     lumpSum: {
       custom: true,
-      statement: '%name%, withdraw {{0}} in {{1}} from your {{2}} and invest the proceeds to your {{3}}',
-      types: [EditCellType.number, EditCellType.date, EditCellType.select, EditCellType.select],
-      options: ['', '', '+investments', '+investments'],
     },
     regular: {
       custom: true,
-      statement:
-        '%name%, make a regular contribution of {{0}} per {{1}} from {{2}} to {{3}} into your {{4}} from {{5}}',
-      types: [
-        EditCellType.number,
-        EditCellType.select,
-        EditCellType.date,
-        EditCellType.date,
-        EditCellType.select,
-        EditCellType.select,
-      ],
-      options: ['', periodTypes, '', '', '+investments', '+investments'],
     },
   },
   withdrawFunds: {
     lumpSum: {
       custom: true,
-      statement: '%name%, make a lump sum withdawal of {{0}} in {{1}} from your {{2}}. Direct the proceeds into {{3}}',
-      types: [EditCellType.number, EditCellType.date, EditCellType.select, EditCellType.select],
-      options: ['', '', '+investments', '+investments'],
     },
     regular: {
       custom: true,
-      statement:
-        '%name%, make a regular withdawal of {{0}} per {{1}} from {{2}} to {{3}} to your {{4}}. ' +
-        'Direct to proceeds into {{5}}',
-      types: [
-        EditCellType.number,
-        EditCellType.select,
-        EditCellType.date,
-        EditCellType.date,
-        EditCellType.select,
-        EditCellType.select,
-      ],
-      options: ['', periodTypes, '', '', '+investments', '+investments'],
     },
   },
   payDownLoan: {

--- a/src/sagas/client/strategy.json
+++ b/src/sagas/client/strategy.json
@@ -1,4 +1,6 @@
 {
+  "clientId": 5,
+  "soaId": 1,
   "defaultFullValue": 2210,
   "client": {
     "name": "John Samual",

--- a/src/sagas/client/strategy.json
+++ b/src/sagas/client/strategy.json
@@ -180,12 +180,12 @@
       {
         "check": true,
         "sentence": "client.salarySacrifice.maximise",
-        "values": ["2019-07-09T12:00:00", "2020-07-10T12:00:00"]
+        "values": [1, "2019-07-09T12:00:00", "2020-07-10T12:00:00"]
       },
       {
         "check": true,
         "sentence": "partner.salarySacrifice.fixedRegular",
-        "values": [3500, "annum", "2019-07-09T12:00:00", "2020-07-10T12:00:00"]
+        "values": [3500, "annum", 4, "2019-07-09T12:00:00", "2020-07-10T12:00:00"]
       },
       {
         "check": true,
@@ -195,7 +195,7 @@
       {
         "check": false,
         "sentence": "partner.salarySacrifice.customOneOff",
-        "values": [2500, 2020]
+        "values": [2500, 5, 2020]
       },
       {
         "check": true,

--- a/src/sagas/client/strategy.json
+++ b/src/sagas/client/strategy.json
@@ -2083,7 +2083,7 @@
       {
         "check": false,
         "sentence": "client.existingInvestment.regular",
-        "values": [2, "2020-07-10T12:00:00", "2022-07-10T12:00:00", 3]
+        "values": [300, "month", 2, "2020-07-10T12:00:00", "2022-07-10T12:00:00", 3]
       },
       {
         "check": true,


### PR DESCRIPTION
Ref: kodiakorg/financial#97

TODO:
---
- [x] Can you send two extra keys at the top of the JSON
i.e.
clientId: 5
soaId: 1
I believe these values are currently returned by the Current Position API
- [x] For all the Salary sacrifice sentences, add another dropdown with the Superannuation items (these are at the top of the JSON now, under the superannuation key: Superannuation Product 1, Superannuation Product 2, etc)
i.e.
salarySacrifice.maximise:
John Samual, maximise salary sacrifice contributions into <Superannuation product 1> from Aug 2019 to Aug 2019
salarySacrifice.fixedRegular:
John Samual, salary sacrifice $0 per annum into <Superannuation product 2> from Aug 2019 to Aug 2019
salarySacrifice.customOneOff:
John Samual, salary sacrifice $0 into <Superannuation product 3> in 2019/20 Financial Year
Note: If there is only one item in the dropdown, pre-populate the dropdown with this one item.
- [x] Adding a dollar amount and frequency input field, to the sentence existingInvestment.regular
i.e.
Instead of:
“John Samual, make a regular contribution into IP1 from Aug 2019 to Aug 2020. The contributions are to be funded from IP2”
It should be:
“John Samual, make a regular contribution of $0 per month into IP1 from Aug 2019 to Aug 2020. The contributions are to be funded from IP2"